### PR TITLE
Remove clap dependency, use Args from crate root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,55 +220,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.6.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
-dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
-dependencies = [
- "anstyle",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "arboard"
 version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,46 +747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.5.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
-
-[[package]]
 name = "clipboard-win"
 version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,12 +764,6 @@ dependencies = [
  "termcolor",
  "unicode-width",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "com"
@@ -1298,7 +1203,6 @@ version = "0.1.0"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
- "clap",
  "dotenv",
  "eframe",
  "lettre",
@@ -1745,12 +1649,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2074,12 +1972,6 @@ name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
-
-[[package]]
-name = "is_terminal_polyfill"
-version = "1.70.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -3501,12 +3393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3887,12 +3773,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ build = "build.rs"
 [dependencies]
 aes-gcm = "0.10.3"
 base64 = "0.22.1"
-clap = { version = "4.0", features = ["derive"] }
 eframe = "0.29.1"
 lettre = "0.11.9"
 oauth2 = "4.4.2"

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,57 +1,26 @@
-use clap::Parser;
-
-#[derive(Parser, Debug, Default, Clone)]
-#[command(author, version, about, long_about = None)]
+#[derive(Debug, Default, Clone)]
 pub struct Args {
     /// Email address of the sender
-    #[arg(
-        short = 'f',
-        long,
-        help = "The email address to send the eSIM activation details from"
-    )]
     pub email_from: String,
 
     /// Email address of the recipient
-    #[arg(
-        short = 't',
-        long,
-        help = "The email address to send the eSIM activation details to"
-    )]
     pub email_to: String,
 
     /// BCC email address (optional)
-    #[arg(long, help = "The email address to BCC (optional)")]
     pub bcc: Option<String>,
 
     /// Provider name
-    #[arg(long, help = "The name of the eSIM provider")]
     pub provider: String,
 
     /// Customer name
-    #[arg(short, long, help = "The name used to sign the email")]
     pub name: String,
 
     /// Data amount
-    #[arg(
-        short,
-        long,
-        help = "The amount of data included in the eSIM plan (e.g., '5GB')"
-    )]
     pub data_amount: String,
 
     /// Time period
-    #[arg(
-        short = 'p',
-        long,
-        help = "The validity period of the eSIM plan (e.g., '30 days')"
-    )]
     pub time_period: String,
 
     /// Location
-    #[arg(
-        short,
-        long,
-        help = "The location for the eSIM (e.g., 'Egypt', 'Middle East')"
-    )]
     pub location: String,
 }

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,6 +1,6 @@
-use crate::args::Args;
 use crate::oauth::determine_provider;
 use crate::templates::load_templates;
+use crate::Args;
 use base64::{self, Engine};
 use lettre::message::header;
 use lettre::transport::smtp::authentication::{Credentials, Mechanism};

--- a/src/gui.rs
+++ b/src/gui.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread;
 
-use crate::{args::Args, get_or_refresh_token, send_email};
+use crate::{get_or_refresh_token, send_email, Args};
 
 pub struct EsimMailerApp {
     args: Args,


### PR DESCRIPTION
Since this is a GUI instead of a CLI now and the `clap` dependency isn't being directly used anymore it can be removed (easy to add back later if you want it). This also makes dependent modules uses the `Args` struct from the re-export in the crate root.