### PR TITLE
Use an email::Provider enum instead of strings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1213,6 +1213,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "thiserror",
  "url",
  "webbrowser",
  "winapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ rfd = "0.15.0"
 serde = "1.0.210"
 serde_json = "1.0.132"
 sha2 = "0.10.8"
+thiserror = "1.0.64"
 url = "2.5.2"
 webbrowser = "1.0.2"
 


### PR DESCRIPTION
Using a `Provider` enum with `Gmail` and `Outlook` variants can remove a couple of error handling scenarios from deeper parts of the application and push that parsing higher up the stack. This doesn't resolve the fact that an invalid email address can still crash the app, but it might still be a small improvement.