### PR TITLE
Fixing PR checks to use fake secrets

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -7,4 +7,9 @@ on:
 jobs:
   build-and-test:
     uses: ./.github/workflows/build.yml
-    secrets: inherit
+    with:
+      release: false
+    secrets:
+      GMAIL_CLIENT_ID: FakeSecret1
+      GMAIL_CLIENT_SECRET: FakeSecret2
+      OUTLOOK_CLIENT_ID: FakeSecret3


### PR DESCRIPTION
PR Checks is failing for other users besides myself because GitHub is smart in not letting people sniff out sensitive secrets from the repo. As such, for pr checks only, I now provide fake secrets.