### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,5 +1,8 @@
 name: Security Audit
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/petersonmichaelj/esim-mailer/security/code-scanning/6](https://github.com/petersonmichaelj/esim-mailer/security/code-scanning/6)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will restrict the permissions of the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the workflow to perform its tasks. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
