### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,5 +1,8 @@
 name: Code Coverage
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/petersonmichaelj/esim-mailer/security/code-scanning/4](https://github.com/petersonmichaelj/esim-mailer/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function correctly. Based on the tasks performed in the workflow, the `contents: read` permission is sufficient, as the workflow only needs to read repository contents and does not perform any write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
